### PR TITLE
Update DefenseTech.json

### DIFF
--- a/DefenseTech.json
+++ b/DefenseTech.json
@@ -1,5 +1,5 @@
 {
-    "Name":"DefenceTech",
+    "Name":"DefenseTech",
     "Version":"v1.0.1.46",
     "MCVersion":["1.7.10"],
     "Link":"http://aidancbrady.com/wp-content/uploads/defensetech/46/DefenseTech-1.7.10-1.0.1.46.jar",


### PR DESCRIPTION
Changing name "DefenceTech" to "DefenseTech" due to alternate spelling causing a "Mod DefenceTech not found." error.

I'm making a pull request for this since you originally added the mod to the archive.